### PR TITLE
Install libatomic on CentOS; remove a couple of LLVM packages on Ubuntu

### DIFF
--- a/docker_setup_scripts/centos7.sh
+++ b/docker_setup_scripts/centos7.sh
@@ -17,6 +17,7 @@ packages=(
     ccache
     curl
     devtoolset-8
+    devtoolset-8-libatomic-devel
     epel-release
     gcc
     gcc-c++
@@ -25,6 +26,7 @@ packages=(
     java-1.8.0-openjdk
     java-1.8.0-openjdk-devel
     less
+    libatomic
     libffi-devel
     libselinux-python
     libsemanage-python

--- a/docker_setup_scripts/ubuntu_install_llvm_packages.sh
+++ b/docker_setup_scripts/ubuntu_install_llvm_packages.sh
@@ -13,6 +13,11 @@ EOT
 
 apt-get update
 
+not_installed_packages=(
+    libllvm-$CLANG_VERSION-ocaml-dev
+    libomp-$CLANG_VERSION-dev
+)
+
 packages=(
     clang-$CLANG_VERSION
     clang-$CLANG_VERSION-doc
@@ -25,9 +30,7 @@ packages=(
     libclang-common-$CLANG_VERSION-dev
     libclang1-$CLANG_VERSION
     libfuzzer-$CLANG_VERSION-dev
-    libllvm-$CLANG_VERSION-ocaml-dev
     libllvm$CLANG_VERSION
-    libomp-$CLANG_VERSION-dev
     lld-$CLANG_VERSION
     lldb-$CLANG_VERSION
     llvm-$CLANG_VERSION


### PR DESCRIPTION
If libatomic is not installed, YugabyteDB build fails in a really cryptic way when trying to use devtoolset-8's GCC. It fails to find Boost because it fails to find Threads (pthreads), and that happens because the CheckIncludeFile tries to compile a test program that does not compile because it can't find libatomic.