### PR TITLE
Install groff-base pkg in ubuntu1804 image for soelim command

### DIFF
--- a/docker_setup_scripts/ubuntu1804.sh
+++ b/docker_setup_scripts/ubuntu1804.sh
@@ -40,6 +40,7 @@ packages=(
     vim
     wget
     xz-utils
+    groff-base
 )
 
 echo "::group::Installing Ubuntu packages"


### PR DESCRIPTION
`seolim` is required to build openldap from thirdparty 