### PR TITLE
Update Clang 11 tarball for CentOS; only create symlinks for clang/clang++

### DIFF
--- a/docker_setup_scripts/centos_install_custom_built_llvm.sh
+++ b/docker_setup_scripts/centos_install_custom_built_llvm.sh
@@ -7,7 +7,7 @@ llvm_major_version=11
 llvm_tarball_version_suffix=1604022592
 llvm_full_version=$llvm_major_version.0.0
 llvm_tarball_version=v${llvm_full_version}-${llvm_tarball_version_suffix}
-llvm_dir_name=llvm-$llvm_tarball_version
+llvm_dir_name=yb-llvm-$llvm_tarball_version
 tarball_name=$llvm_dir_name.tar.gz
 url=$URL_PREFIX/$llvm_tarball_version/$tarball_name
 cd /opt/yb-build/llvm

--- a/docker_setup_scripts/centos_install_custom_built_llvm.sh
+++ b/docker_setup_scripts/centos_install_custom_built_llvm.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 readonly URL_PREFIX=https://github.com/yugabyte/build-clang/releases/download
 
 llvm_major_version=11
-llvm_tarball_version=v${llvm_major_version}.0.0-v4
+llvm_tarball_version_suffix=1604022592
+llvm_tarball_version=v${llvm_major_version}-${llvm_tarball_version_suffix}
 llvm_dir_name=llvm-$llvm_tarball_version
 tarball_name=$llvm_dir_name.tar.gz
 url=$URL_PREFIX/$llvm_tarball_version/$tarball_name
@@ -30,117 +31,9 @@ fi
 symlink_parent_dir=/usr/local/bin
 mkdir -p "$symlink_parent_dir"
 
-# This is based on symlinks created by LLVM/Clang packages in /usr/bin on Ubuntu.
 readonly LLVM_TOOLS_TO_LINK=(
-    FileCheck
-    bugpoint
-    c-index-test
     clang
     clang++
-    clang-apply-replacements
-    clang-change-namespace
-    clang-check
-    clang-cl
-    clang-cpp
-    clang-doc
-    clang-extdef-mapping
-    clang-format
-    clang-include-fixer
-    clang-move
-    clang-offload-bundler
-    clang-offload-wrapper
-    clang-query
-    clang-refactor
-    clang-rename
-    clang-reorder-fields
-    clang-scan-deps
-    clangd
-    count
-    diagtool
-    dsymutil
-    find-all-symbols
-    git-clang-format
-    hmaptool
-    ld.lld
-    ld64.lld
-    llc
-    lld
-    lld-link
-    lldb
-    lldb-argdumper
-    lldb-instr
-    lldb-server
-    lldb-vscode
-    lli
-    lli-child-target
-    llvm-PerfectShuffle
-    llvm-addr2line
-    llvm-ar
-    llvm-as
-    llvm-bcanalyzer
-    llvm-c-test
-    llvm-cat
-    llvm-cfi-verify
-    llvm-config
-    llvm-cov
-    llvm-cvtres
-    llvm-cxxdump
-    llvm-cxxfilt
-    llvm-cxxmap
-    llvm-diff
-    llvm-dis
-    llvm-dlltool
-    llvm-dwarfdump
-    llvm-dwp
-    llvm-elfabi
-    llvm-exegesis
-    llvm-extract
-    llvm-gsymutil
-    llvm-ifs
-    llvm-install-name-tool
-    llvm-jitlink
-    llvm-lib
-    llvm-link
-    llvm-lipo
-    llvm-lto
-    llvm-lto2
-    llvm-mc
-    llvm-mca
-    llvm-ml
-    llvm-modextract
-    llvm-mt
-    llvm-nm
-    llvm-objcopy
-    llvm-objdump
-    llvm-opt-report
-    llvm-pdbutil
-    llvm-profdata
-    llvm-ranlib
-    llvm-rc
-    llvm-readelf
-    llvm-readobj
-    llvm-reduce
-    llvm-rtdyld
-    llvm-size
-    llvm-split
-    llvm-stress
-    llvm-strings
-    llvm-strip
-    llvm-symbolizer
-    llvm-tblgen
-    llvm-undname
-    llvm-xray
-    modularize
-    not
-    obj2yaml
-    opt
-    pp-trace
-    sancov
-    sanstats
-    verify-uselistorder
-    wasm-ld
-    yaml-bench
-    yaml2obj
 )
 
 for tool_name in "${LLVM_TOOLS_TO_LINK[@]}"; do
@@ -149,7 +42,6 @@ for tool_name in "${LLVM_TOOLS_TO_LINK[@]}"; do
   if [[ -f $tool_path ]]; then
     ( set -x; ln -s "$tool_path" "$link_path" )
   else
-    echo "LLVM/Clang tool does not exist: $tool_path, not creating a symlink at" \
-         "$link_path" >&2
+    fatal "LLVM/Clang tool does not exist: $tool_path"
   fi
 done

--- a/docker_setup_scripts/centos_install_custom_built_llvm.sh
+++ b/docker_setup_scripts/centos_install_custom_built_llvm.sh
@@ -5,7 +5,8 @@ readonly URL_PREFIX=https://github.com/yugabyte/build-clang/releases/download
 
 llvm_major_version=11
 llvm_tarball_version_suffix=1604022592
-llvm_tarball_version=v${llvm_major_version}-${llvm_tarball_version_suffix}
+llvm_full_version=$llvm_major_version.0.0
+llvm_tarball_version=v${llvm_full_version}-${llvm_tarball_version_suffix}
 llvm_dir_name=llvm-$llvm_tarball_version
 tarball_name=$llvm_dir_name.tar.gz
 url=$URL_PREFIX/$llvm_tarball_version/$tarball_name

--- a/docker_setup_scripts/centos_install_custom_built_llvm.sh
+++ b/docker_setup_scripts/centos_install_custom_built_llvm.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env
+#!/usr/bin/env bash
 
 set -euo pipefail
 readonly URL_PREFIX=https://github.com/yugabyte/build-clang/releases/download
@@ -11,10 +11,11 @@ llvm_dir_name=yb-llvm-$llvm_tarball_version
 tarball_name=$llvm_dir_name.tar.gz
 url=$URL_PREFIX/$llvm_tarball_version/$tarball_name
 cd /opt/yb-build/llvm
-wget "$url"
 
+curl -sLO "$url"
 actual_sha256sum=$( sha256sum "$tarball_name" | awk '{print $1}')
-expected_sha256sum="85618e7fb91e80a37c26e02e7113d5fbbd4edc50779ca78b0170d6f7911f03b4"
+expected_sha256sum=$( curl -sL "$url.sha256" | awk '{print $1}' )
+
 if [[ $actual_sha256sum != $expected_sha256sum ]]; then
   echo "Checksum mismatch for $tarball_name: expected $expected_sha256sum," \
        "got $actual_sha256sum" >&2
@@ -32,10 +33,7 @@ fi
 symlink_parent_dir=/usr/local/bin
 mkdir -p "$symlink_parent_dir"
 
-readonly LLVM_TOOLS_TO_LINK=(
-    clang
-    clang++
-)
+readonly LLVM_TOOLS_TO_LINK=( clang clang++ )
 
 for tool_name in "${LLVM_TOOLS_TO_LINK[@]}"; do
   tool_path=$installed_llvm_bin_dir/$tool_name


### PR DESCRIPTION
- Update Clang 11 tarball for CentOS to a new build
- Only create symlinks for clang/clang++ in /usr/local/bin on CentOS, not for all kinds of LLVM-provided tools. This creates a difference between Ubuntu and CentOS setup but that is OK.
- Do not hardcode tarball checksum, download it from the corresponding .sha256 URL.