### PR TITLE
Add locale-related packages on RedHat 8 family of OSes

### DIFF
--- a/docker_setup_scripts/centos.sh
+++ b/docker_setup_scripts/centos.sh
@@ -79,6 +79,7 @@ readonly CENTOS8_ONLY_PACKAGES=(
   python38
   python38-devel
   python38-pip
+  python38-psutil
 )
 
 # -------------------------------------------------------------------------------------------------

--- a/docker_setup_scripts/centos.sh
+++ b/docker_setup_scripts/centos.sh
@@ -80,6 +80,9 @@ readonly CENTOS8_ONLY_PACKAGES=(
   python38-devel
   python38-pip
   python38-psutil
+
+  glibc-locale-source
+  glibc-langpack-en
 )
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Also add python38-psutil which is used by our Spark-based test runner.