### PR TITLE
Change spark download URL since dlcdn does not keep old releases.

### DIFF
--- a/docker_setup_scripts/install_spark.sh
+++ b/docker_setup_scripts/install_spark.sh
@@ -5,7 +5,7 @@ set -euo pipefail -x
 spark_version=3.2.1
 spark_dir_name="spark-${spark_version}-bin-hadoop3.2"
 spark_tarball_name="$spark_dir_name.tgz"
-spark_download_url="https://dlcdn.apache.org/spark/spark-${spark_version}/${spark_tarball_name}"
+spark_download_url="https://archive.apache.org/dist/spark/spark-${spark_version}/${spark_tarball_name}"
 
 spark_parent_dir=/opt/yb-build/spark
 mkdir -p "${spark_parent_dir}"


### PR DESCRIPTION
Changed spark download URL from `https://dlcdn.apache.org` to `https://archive.apache.org` since the former does not keep old releases around (e.g. Spark 3.2.1 cannot be found on dlcdn, since 3.2.2 is the current 3.2 release).