### PR TITLE
Add AlmaLinux 9 support

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -26,10 +26,11 @@ jobs:
       matrix:
         image_name:
           - centos7
+          - almalinux8
+          - almalinux9
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - almalinux8
 
     runs-on: ubuntu-latest
     if: >

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -65,7 +65,9 @@ while [[ $# -gt 0 ]]; do
       shift
     ;;
     *)
-      fatal "Unknown command: $1"
+      print_usage >&2
+      echo >&2
+      fatal "Unknown option: $1"
   esac
   shift
 done

--- a/docker_images/almalinux9/Dockerfile
+++ b/docker_images/almalinux9/Dockerfile
@@ -1,0 +1,5 @@
+FROM almalinux:9
+
+COPY docker_setup_scripts /tmp/yb_docker_setup_scripts
+
+RUN bash /tmp/yb_docker_setup_scripts/redhat.sh

--- a/docker_setup_scripts/debian.sh
+++ b/docker_setup_scripts/debian.sh
@@ -42,5 +42,5 @@ packages=(
 )
 
 yb_debian_configure_and_install_packages "${packages[@]}"
-yb_perform_os_independent_steps
+yb_perform_universal_steps
 yb_remove_build_infra_scripts

--- a/docker_setup_scripts/docker_setup_scripts_common.sh
+++ b/docker_setup_scripts/docker_setup_scripts_common.sh
@@ -390,3 +390,8 @@ run_cmd_hide_output_if_ok() {
   fi
   rm -f "${stdout_path}" "${stderr_path}"
 }
+
+yb_fatal_unknown_architecture() {
+  echo >&2 "Unknown architecture: $( uname -m )"
+  exit 1
+}

--- a/docker_setup_scripts/docker_setup_scripts_common.sh
+++ b/docker_setup_scripts/docker_setup_scripts_common.sh
@@ -357,7 +357,7 @@ yb_install_go_packages() {
   rm -rf "$GOPATH"
 }
 
-yb_perform_os_independent_steps() {
+yb_perform_universal_steps() {
   yb_create_yugabyteci_user
   yb_install_golang
   yb_install_hub_tool

--- a/docker_setup_scripts/opensuse.sh
+++ b/docker_setup_scripts/opensuse.sh
@@ -53,7 +53,7 @@ packages=(
 # -------------------------------------------------------------------------------------------------
 
 yb_zypper_install_packages_separately "${packages[@]}"
-yb_perform_os_independent_steps
+yb_perform_universal_steps
 yb_remove_build_infra_scripts
 
 zypper clean

--- a/docker_setup_scripts/redhat.sh
+++ b/docker_setup_scripts/redhat.sh
@@ -223,6 +223,8 @@ if [[ $os_major_version -eq 7 ]]; then
   yb_install_python3_from_source
 fi
 
-# yb_redhat_init_locale
+if [[ $os_major_version -lt 9 ]]; then
+  yb_redhat_init_locale
+fi
 
 yb_remove_build_infra_scripts

--- a/docker_setup_scripts/redhat.sh
+++ b/docker_setup_scripts/redhat.sh
@@ -90,6 +90,10 @@ readonly RHEL7_8_ONLY_PACKAGES=(
   curl
 )
 
+readonly RHEL9_ONLY_PACKAGES=(
+  perl-FindBin
+)
+
 # -------------------------------------------------------------------------------------------------
 # Functions
 # -------------------------------------------------------------------------------------------------
@@ -151,6 +155,7 @@ install_packages() {
   elif [[ $os_major_version -eq 9 ]]; then
     gcc_toolsets_to_install=()
     package_manager=dnf
+    packages+=( "${RHEL9_ONLY_PACKAGES[@]}" )
   else
     echo "Unknown RHEL family OS major version: $os_major_version" >&2
     exit 1

--- a/docker_setup_scripts/redhat.sh
+++ b/docker_setup_scripts/redhat.sh
@@ -34,10 +34,8 @@ readonly REDHAT_COMMON_PACKAGES=(
   bzip2-devel
   ccache
   chrpath
-  curl
   gcc
   gcc-c++
-  gdbm-devel
   git
   glibc-all-langpacks
   java-1.8.0-openjdk
@@ -56,8 +54,6 @@ readonly REDHAT_COMMON_PACKAGES=(
   php
   php-common
   php-curl
-  python2
-  python2-pip
   readline-devel
   rsync
   ruby
@@ -85,6 +81,13 @@ readonly RHEL8_ONLY_PACKAGES=(
 
   glibc-locale-source
   glibc-langpack-en
+)
+
+readonly RHEL7_8_ONLY_PACKAGES=(
+  gdbm-devel
+  python2
+  python2-pip
+  curl
 )
 
 # -------------------------------------------------------------------------------------------------
@@ -137,14 +140,19 @@ install_packages() {
     esac
     package_manager=yum
     packages+=( "${CENTOS7_ONLY_PACKAGES[@]}" )
+    packages+=( "${RHEL7_8_ONLY_PACKAGES[@]}" )
   elif [[ $os_major_version -eq 8 ]]; then
     toolset_prefix="gcc-toolset"
     gcc_toolsets_to_install=( "${RHEL8_GCC_TOOLSETS_TO_INSTALL[@]}" )
     toolset_package_suffixes+=( "${TOOLSET_PACKAGE_SUFFIXES_RHEL8[@]}" )
     package_manager=dnf
     packages+=( "${RHEL8_ONLY_PACKAGES[@]}" )
+    packages+=( "${RHEL7_8_ONLY_PACKAGES[@]}" )
+  elif [[ $os_major_version -eq 9 ]]; then
+    gcc_toolsets_to_install=()
+    package_manager=dnf
   else
-    echo "Unknown CentOS major version: $os_major_version" >&2
+    echo "Unknown RHEL family OS major version: $os_major_version" >&2
     exit 1
   fi
 
@@ -201,7 +209,7 @@ install_packages
 
 yb_yum_cleanup
 
-yb_perform_os_independent_steps
+yb_perform_universal_steps
 
 yb_install_cmake
 yb_install_ninja
@@ -210,6 +218,6 @@ if [[ $os_major_version -eq 7 ]]; then
   yb_install_python3_from_source
 fi
 
-yb_redhat_init_locale
+# yb_redhat_init_locale
 
 yb_remove_build_infra_scripts

--- a/docker_setup_scripts/redhat.sh
+++ b/docker_setup_scripts/redhat.sh
@@ -18,6 +18,9 @@ readonly TOOLSET_PACKAGE_SUFFIXES_COMMON=(
 
 readonly TOOLSET_PACKAGE_SUFFIXES_RHEL8=(
   toolchain
+)
+
+readonly TOOLSET_PACKAGE_SUFFIXES_RHEL8_9=(
   gcc
   gcc-c++
 )
@@ -25,6 +28,7 @@ readonly TOOLSET_PACKAGE_SUFFIXES_RHEL8=(
 readonly CENTOS7_GCC_TOOLSETS_TO_INSTALL_X86_64=( 11 )
 readonly CENTOS7_GCC_TOOLSETS_TO_INSTALL_AARCH64=( 10 )
 readonly RHEL8_GCC_TOOLSETS_TO_INSTALL=( 11 )
+readonly RHEL9_GCC_TOOLSETS_TO_INSTALL=( 12 )
 
 # Packages installed on all supported versions of CentOS.
 readonly REDHAT_COMMON_PACKAGES=(
@@ -85,18 +89,38 @@ readonly RHEL8_ONLY_PACKAGES=(
 
 readonly RHEL7_8_ONLY_PACKAGES=(
   gdbm-devel
-  python2
-  python2-pip
   curl
 )
 
+# Attempting to install curl on AlmaLinux 9 leads to the following error:
+#
+# https://gist.githubusercontent.com/mbautin/65b076bdb6a621de721df91ff66c1579/raw
+#
+# We are making sure that curl-minimal is installed instead, for clarity. However, it is required by
+# dnf so it will always be installed anyway.
 readonly RHEL9_ONLY_PACKAGES=(
   perl-FindBin
+  curl-minimal
 )
 
 # -------------------------------------------------------------------------------------------------
 # Functions
 # -------------------------------------------------------------------------------------------------
+
+yb_fatal_unsupported_rhel_major_version() {
+  (
+    echo "Unsupported major version of CentOS/AlmaLinux/RHEL: $os_major_version"
+    echo "(from /etc/os-release)"
+    echo
+    echo "--------------------------------------------------------------------------------------"
+    echo "Contents of /etc/os-release"
+    echo "--------------------------------------------------------------------------------------"
+    cat /etc/os-release
+    echo "--------------------------------------------------------------------------------------"
+    echo
+  ) >&2
+  exit 1
+}
 
 detect_os_version() {
   os_major_version=$(
@@ -104,18 +128,7 @@ detect_os_version() {
   )
   os_major_version=${os_major_version%%.*}
   if [[ ! $os_major_version =~ ^[789]$ ]]; then
-    (
-      echo "Unsupported major version of CentOS/AlmaLinux/RHEL: $os_major_version"
-      echo "(from /etc/os-release)"
-      echo
-      echo "--------------------------------------------------------------------------------------"
-      echo "Contents of /etc/os-release"
-      echo "--------------------------------------------------------------------------------------"
-      cat /etc/os-release
-      echo "--------------------------------------------------------------------------------------"
-      echo
-    ) >&2
-    exit 1
+    yb_fatal_unsupported_rhel_major_version
   fi
   readonly os_major_version
 }
@@ -123,43 +136,49 @@ detect_os_version() {
 install_packages() {
   local packages=( "${REDHAT_COMMON_PACKAGES[@]}" )
 
-  local toolset_prefix
-  local gcc_toolsets_to_install
-  local package_manager
+  # The settings below are used on RHEL 8 and later. We override them for CentOS 7.
+  local toolset_prefix="gcc-toolset"
+  local package_manager=dnf
+
+  local gcc_toolsets_to_install=()
   local toolset_package_suffixes=( "${TOOLSET_PACKAGE_SUFFIXES_COMMON[@]}" )
-  if [[ $os_major_version -eq 7 ]]; then
-    toolset_prefix="devtoolset"
-    local gcc_toolsets_to_install
-    case "$( uname -m )" in
-      x86_64)
-        gcc_toolsets_to_install=( "${CENTOS7_GCC_TOOLSETS_TO_INSTALL_X86_64[@]}" )
-      ;;
-      aarch64)
-        gcc_toolsets_to_install=( "${CENTOS7_GCC_TOOLSETS_TO_INSTALL_AARCH64[@]}" )
-      ;;
-      *)
-        echo >&2 "Unknown architecture: $( uname -m )"
-        exit 1
-      ;;
-    esac
-    package_manager=yum
-    packages+=( "${CENTOS7_ONLY_PACKAGES[@]}" )
-    packages+=( "${RHEL7_8_ONLY_PACKAGES[@]}" )
-  elif [[ $os_major_version -eq 8 ]]; then
-    toolset_prefix="gcc-toolset"
-    gcc_toolsets_to_install=( "${RHEL8_GCC_TOOLSETS_TO_INSTALL[@]}" )
-    toolset_package_suffixes+=( "${TOOLSET_PACKAGE_SUFFIXES_RHEL8[@]}" )
-    package_manager=dnf
-    packages+=( "${RHEL8_ONLY_PACKAGES[@]}" )
-    packages+=( "${RHEL7_8_ONLY_PACKAGES[@]}" )
-  elif [[ $os_major_version -eq 9 ]]; then
-    gcc_toolsets_to_install=()
-    package_manager=dnf
-    packages+=( "${RHEL9_ONLY_PACKAGES[@]}" )
-  else
-    echo "Unknown RHEL family OS major version: $os_major_version" >&2
-    exit 1
-  fi
+  case "${os_major_version}" in
+    7)
+      toolset_prefix="devtoolset"
+      case "$( uname -m )" in
+        x86_64)
+          gcc_toolsets_to_install=( "${CENTOS7_GCC_TOOLSETS_TO_INSTALL_X86_64[@]}" )
+        ;;
+        aarch64)
+          gcc_toolsets_to_install=( "${CENTOS7_GCC_TOOLSETS_TO_INSTALL_AARCH64[@]}" )
+        ;;
+        *)
+          yb_fatal_unknown_architecture
+      esac
+      package_manager=yum
+      packages+=( "${CENTOS7_ONLY_PACKAGES[@]}" )
+      packages+=( "${RHEL7_8_ONLY_PACKAGES[@]}" )
+    ;;
+    8)
+      gcc_toolsets_to_install=( "${RHEL8_GCC_TOOLSETS_TO_INSTALL[@]}" )
+      toolset_package_suffixes+=(
+        "${TOOLSET_PACKAGE_SUFFIXES_RHEL8[@]}"
+        "${TOOLSET_PACKAGE_SUFFIXES_RHEL8_9[@]}"
+      )
+      packages+=( "${RHEL8_ONLY_PACKAGES[@]}" )
+      packages+=( "${RHEL7_8_ONLY_PACKAGES[@]}" )
+    ;;
+    9)
+      gcc_toolsets_to_install=( "${RHEL9_GCC_TOOLSETS_TO_INSTALL[@]}" )
+      toolset_package_suffixes+=(
+        "${TOOLSET_PACKAGE_SUFFIXES_RHEL8_9[@]}"
+      )
+      package_manager=dnf
+      packages+=( "${RHEL9_ONLY_PACKAGES[@]}" )
+    ;;
+    *)
+      yb_fatal_unsupported_rhel_major_version
+  esac
 
   local gcc_toolset_version
   for gcc_toolset_version in "${gcc_toolsets_to_install[@]}"; do

--- a/docker_setup_scripts/ubuntu.sh
+++ b/docker_setup_scripts/ubuntu.sh
@@ -65,5 +65,5 @@ if [[ $ubuntu_major_version -le 18 ]]; then
 fi
 
 yb_debian_configure_and_install_packages "${packages[@]}"
-yb_perform_os_independent_steps
+yb_perform_universal_steps
 yb_remove_build_infra_scripts


### PR DESCRIPTION
Add an AlmaLinux 9 image for both x86_64 and aarch64 architectures.

Remove Python 2 packages from CentOS and AlmaLinux images.