### PR TITLE
Add python3-devel package on AlmaLinux 9 [skip ci]

### DIFF
--- a/docker_setup_scripts/redhat.sh
+++ b/docker_setup_scripts/redhat.sh
@@ -101,6 +101,7 @@ readonly RHEL7_8_ONLY_PACKAGES=(
 readonly RHEL9_ONLY_PACKAGES=(
   perl-FindBin
   curl-minimal
+  python3-devel
 )
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Tested manually by running `dnf install -y python3-devel` on AlmaLinux 9 x86_64 and aarch64.