### PR TITLE
Simplifying CI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
         type: string
       arch:
         type: string
-      
+
     machine:
       image: ubuntu-2204:current
       resource_class: arm.large
@@ -30,32 +30,15 @@ jobs:
           name: Build and push the image
           command: |
             github_org=${CIRCLE_PROJECT_USERNAME}
-            if [[ $github_org == "yugabyte" ]]; then
-              dockerhub_org="yugabyteci"
-              dockerhub_user="yugabyteci"
-            else
-              dockerhub_org=$github_org
-              dockerhub_user=$github_org
+            is_pr=false
+            if [[ -n ${CIRCLE_PULL_REQUEST:-} ]]; then
+              is_pr=true
             fi
-            echo "DockerHub organization: $dockerhub_org"
-            echo "DockerHub user: $dockerhub_user"
             bin/build_docker_images.sh \
               -i "<< parameters.image_name >>" \
-              --tag_prefix "$dockerhub_org" \
-              --tag_output_file docker_tag.txt
+              --github_org "$github_org" \
+              --is_pr "$is_pr"
 
-            if [[ -z ${CIRCLE_PULL_REQUEST:-} ]]; then
-              echo "This is not a PR, doing a DockerHub push."
-              echo "Logging into DockerHub as user '$dockerhub_user'"
-              echo "${DOCKERHUB_TOKEN}" | \
-                docker login -u "$dockerhub_user" --password-stdin
-
-              docker_tag=$(<docker_tag.txt)
-              echo "Docker tag: $docker_tag"
-              ( set -x; docker push "$docker_tag" )
-            else
-              echo "This is a PR ( $CIRCLE_PULL_REQUEST ), not doing a DockerHub push."
-            fi
 
 workflows:
   build-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,10 @@ jobs:
               is_pr=true
             fi
             bin/build_docker_images.sh \
-              -i "<< parameters.image_name >>" \
+              --image_name "<< parameters.image_name >>" \
               --github_org "$github_org" \
-              --is_pr "$is_pr"
-
+              --is_pr "$is_pr" \
+              --push
 
 workflows:
   build-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,9 @@
 version: 2.1
 
 jobs:
-  build:
+  aarch64:
     parameters:
       image_name:
-        type: string
-      arch:
         type: string
 
     machine:
@@ -43,7 +41,7 @@ jobs:
 workflows:
   build-workflow:
     jobs:
-      - build:
+      - aarch64:
           matrix:
             parameters:
               image_name:
@@ -52,5 +50,3 @@ workflows:
                 - almalinux9
                 - ubuntu2004
                 - ubuntu2204
-              arch:
-                - aarch64

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -48,24 +48,11 @@ jobs:
       - name: Build and push the image
         run: |
           github_org=${GITHUB_ORG_AND_REPO%%/*}
-          if [[ $github_org == "yugabyte" ]]; then
-            dockerhub_org="yugabyteci"
-            dockerhub_user="yugabyteci"
-          else
-            dockerhub_org=$github_org
-            dockerhub_user=$github_org
+          is_pr=true
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            is_pr=false
           fi
           bin/build_docker_images.sh \
             -i ${{ matrix.image_name }} \
-            --tag_prefix "$dockerhub_org" \
-            --tag_output_file docker_tag.txt
-
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "Logging into DockerHub as user '$dockerhub_user'"
-            echo "${{ secrets.DOCKERHUB_TOKEN }}" | \
-              docker login -u "$dockerhub_user" --password-stdin
-
-            docker_tag=$(<docker_tag.txt)
-            echo "Docker tag: $docker_tag"
-            ( set -x; docker push "$docker_tag" )
-          fi
+            --github_org "$github_org" \
+            --is_pr "$is_pr"

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -19,7 +19,7 @@ env:
   GITHUB_ORG_AND_REPO: "${{ github.repository }}"
 
 jobs:
-  build:
+  x86_64:
 
     strategy:
       fail-fast: false

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -53,6 +53,7 @@ jobs:
             is_pr=false
           fi
           bin/build_docker_images.sh \
-            -i ${{ matrix.image_name }} \
+            --image_name ${{ matrix.image_name }} \
             --github_org "$github_org" \
-            --is_pr "$is_pr"
+            --is_pr "$is_pr" \
+            --push

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -103,8 +103,12 @@ if [[ -z $tag_prefix && -n $github_org ]]; then
     dockerhub_org=$github_org
     dockerhub_user=$github_org
   fi
-  echo "Using DockerHub organization: $dockerhub_org"
-  echo "Using DockerHub user name: $dockerhub_user"
+  log "Using DockerHub organization: $dockerhub_org"
+  log "Using DockerHub user name: $dockerhub_user"
+fi
+
+if [[ $is_pr == "true" && $should_push == "true" ]]; then
+  log "This is a pull request (--is_pr specified as true), will not push to DockerHub."
 fi
 
 if [[ -n $tag_prefix ]]; then

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -29,6 +29,11 @@ Options:
     The file to write the resulting Docker image tag to
   -p, --push
     Push the built image(s) to DockerHub (must be logged in).
+  --is_pr <true|false>
+    Specify whether this is a pull request.
+  --github_org
+    When running on CI/CD, the GitHub organization of the repository being tested, or the user
+    submitting the pull request.
 EOT
 }
 
@@ -42,6 +47,8 @@ image_name=""
 should_push=false
 tag_prefix=""
 tag_output_file=""
+github_org=""
+is_pr=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -64,6 +71,17 @@ while [[ $# -gt 0 ]]; do
       tag_output_file=$2
       shift
     ;;
+    --github_org)
+      github_org=$2
+      shift
+    ;;
+    --is_pr)
+      is_pr=$2
+      if [[ ! $is_pr =~ ^(true|false) ]]; then
+        echo "Invalid value of --is_pr: $is_pr (expected true/false)" >&2
+        exit 1
+      fi
+    ;;
     *)
       print_usage >&2
       echo >&2
@@ -75,6 +93,19 @@ done
 dockerfile_path=$yb_build_infra_root/docker_images/$image_name/Dockerfile
 
 timestamp=$( get_timestamp_for_filenames )
+
+if [[ -z $tag_prefix && -n $github_org ]]; then
+  if [[ $github_org == "yugabyte" ]]; then
+    dockerhub_org="yugabyteci"
+    dockerhub_user="yugabyteci"
+  else
+    dockerhub_org=$github_org
+    dockerhub_user=$github_org
+  fi
+  echo "Using DockerHub organization: $dockerhub_org"
+  echo "Using DockerHub user name: $dockerhub_user"
+fi
+
 if [[ -n $tag_prefix ]]; then
   tag_prefix=$tag_prefix/
 fi
@@ -93,7 +124,18 @@ fi
   docker build -f "$dockerfile_path" -t "$tag" .
 )
 
-if "$should_push"; then
-  log "Pushing $tag to DockerHub (--push specified)."
-  ( set -x; docker push "$tag" )
+if [[ $should_push == "true" ]]; then
+  if [[ $is_pr == "true" ]]; then
+    log "This is a pull request, not pushing to DockerHub"
+  else
+    if [[ -n ${DOCKER_HUB_TOKEN:-} ]]; then
+      log "Logging into DockerHub as user '$dockerhub_user'"
+      echo "${DOCKERHUB_TOKEN}" | \
+        docker login -u "$dockerhub_user" --password-stdin
+    else
+      log "DOCKERHUB_TOKEN is not set, not attempting to log into DockerHub"
+    fi
+
+    ( set -x; docker push "$tag" )
+  fi
 fi

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -81,6 +81,7 @@ while [[ $# -gt 0 ]]; do
         echo "Invalid value of --is_pr: $is_pr (expected true/false)" >&2
         exit 1
       fi
+      shift
     ;;
     *)
       print_usage >&2


### PR DESCRIPTION
Move some logic from GitHub Actions and CircleCI YAML files to build_docker_images.sh.
Also rename the CircleCI job to aarch64 and the GitHub Actions job to x86_64 to make GitHub commit status updates more readable.