### PR TITLE
Add perl-core package on CentOS

### DIFF
--- a/docker_setup_scripts/redhat.sh
+++ b/docker_setup_scripts/redhat.sh
@@ -54,7 +54,7 @@ readonly REDHAT_COMMON_PACKAGES=(
   openssl-devel
   patch
   patchelf
-  perl-Digest
+  perl-core
   php
   php-common
   php-curl


### PR DESCRIPTION
This adds perl-core (and removes perl-Digest, which perl-core includes), [which is needed to build OpenSSL 3.0+](https://github.com/openssl/openssl/blob/master/NOTES-PERL.md#general-notes).