### PR TITLE
Bump CMake to 3.31.0

### DIFF
--- a/docker_setup_scripts/docker_setup_scripts_common.sh
+++ b/docker_setup_scripts/docker_setup_scripts_common.sh
@@ -176,7 +176,6 @@ yb_determine_ubuntu_packages() {
     apt-utils
     automake
     bison
-    cmake
     curl
     flex
     git
@@ -431,6 +430,7 @@ yb_perform_universal_steps() {
   yb_install_rust
   yb_install_go_packages
   yb_install_bazel
+  yb_install_cmake
 }
 
 run_cmd_hide_output_if_ok() {

--- a/docker_setup_scripts/install_cmake.sh
+++ b/docker_setup_scripts/install_cmake.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-version=3.23.2
+version=3.31.0
 work_dir=/tmp/install_cmake
 mkdir -p "$work_dir"
 cd "$work_dir"
@@ -12,8 +12,8 @@ dest_dir=/usr/share/${dest_dir_name}
 tarball_name=$extracted_dir_name.tar.gz
 
 # We want these URLs:
-# https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-x86_64.tar.gz
-# https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-aarch64.tar.gz
+# https://github.com/Kitware/CMake/releases/download/v3.31.0/cmake-3.31.0-linux-x86_64.tar.gz
+# https://github.com/Kitware/CMake/releases/download/v3.31.0/cmake-3.31.0-linux-aarch64.tar.gz
 
 url=https://github.com/Kitware/CMake/releases/download/v$version/$tarball_name
 rm -f "$tarball_name"
@@ -21,9 +21,9 @@ curl --silent -LO "$url"
 actual_sha256sum=$( sha256sum "$tarball_name" | awk '{print $1}' )
 
 if [[ $arch == "x86_64" ]]; then
-  expected_sha256sum=aaced6f745b86ce853661a595bdac6c5314a60f8181b6912a0a4920acfa32708
+  expected_sha256sum=0fcb338b4515044f9ac77543550ac92c314c58f6f95aafcac5cd36aa75db6924
 elif [[ $arch == "aarch64" ]]; then
-  expected_sha256sum=f2654bf780b53f170bbbec44d8ac67d401d24788e590faa53036a89476efa91e
+  expected_sha256sum=e0f74862734c2d14ef8ac5a71941691531db0bbebee0a9c20a8e96e8a97390f9
 else
   echo >&2 "Unknown architecture: $arch"
   exit 1

--- a/docker_setup_scripts/redhat.sh
+++ b/docker_setup_scripts/redhat.sh
@@ -214,7 +214,6 @@ yb_yum_cleanup
 
 yb_perform_universal_steps
 
-yb_install_cmake
 yb_install_ninja
 
 if [[ $os_major_version -lt 9 ]]; then


### PR DESCRIPTION
This is now required to build yugabyte-db, and these images are used by GitHub Actions.